### PR TITLE
🐛  Added overflow-x hidden to html and body to prevent horizontal scroll

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,3 +17,8 @@
        url('/fonts/roboto-v20-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('/fonts/roboto-v20-latin-regular.svg#Roboto') format('svg'); /* Legacy iOS */
 }
+
+html,
+body {
+    overflow-x: hidden;
+}


### PR DESCRIPTION
# Description

Removed horizontal scroll bar by giving overflow-x hidden

## Changes
- global css

## Fixes
- Animation horizontal scroll bar on homepage
- Scroll bar in Blog posts

## Packages
NA

## Additional Information
NA